### PR TITLE
Fix fertilization text/tags parsing in QML

### DIFF
--- a/qml/components_js/UtilsPlantDatabase.js
+++ b/qml/components_js/UtilsPlantDatabase.js
@@ -104,7 +104,7 @@ function getSunlightText(sunlight) {
 function getFertilizationTagsText(fert) {
     var txt = ""
 
-    var tags = fert[1].split('-')
+    var tags = parseInt(fert.split(',')[1]) || 0
 
     if (tags & PlantUtils.PlantUtils.LOW_NEEDS) {
         if (txt.length > 0) txt += ", "
@@ -156,7 +156,7 @@ function getFertilizationTagsText(fert) {
 function getFertilizationText(fert) {
     var txt = ""
 
-    var freq = fert[0].split('-')
+    var freq = parseInt(fert.split(',')[0])
 
     if (freq == PlantUtils.PlantUtils.FERT_NONE) txt = qsTr("no extra fertilization needed")
     else if (freq == PlantUtils.PlantUtils.FERT_THREEWEEKLY) txt = qsTr("every 2-3 days")


### PR DESCRIPTION
getFertilizationText and getFertilizationTagsText were indexing the
fert string by character ('fert[0]', 'fert[1]') instead of splitting
on comma. This worked by accident for single-digit freq values (the
first character coincides with the value), but silently dropped tags
on every plant -- 'fert[1]' on '6,0' returns ','. Split on comma and
parseInt instead; also drop the stray .split('-') which had no effect
since no value in the database contains a dash.
