### PR TITLE
Fix wrap-around month logic in calendar_tostringlist

### DIFF
--- a/src/PlantUtils.h
+++ b/src/PlantUtils.h
@@ -505,7 +505,7 @@ public:
                 if (splt->first <= splt->second) {
                     if (i >= splt->first && i <= splt->second) ret[i-1] = "1";
                 } else {
-                    if (i <= splt->first && i >= splt->second) ret[i-1] = "1";
+                    if (i >= splt->first || i <= splt->second) ret[i-1] = "1";
                 }
             }
         }


### PR DESCRIPTION
For year-wrapping calendar intervals like "12-2" (Dec-Feb), the else
branch matched months 2-12 instead of {12, 1, 2} -- the complement of
the intended set. Plants with winter blooming/fruiting periods (e.g.
Coffea arabica fruiting 12-2, Cymbidium cochleare blooming 12-1)
displayed the wrong months in their calendar widget.

Use OR instead of AND so the wrap-around branch covers months >= first
or <= second.
