### PR TITLE
Read colors_flower from the right JSON key

### DIFF
--- a/src/Plant.cpp
+++ b/src/Plant.cpp
@@ -200,7 +200,7 @@ void Plant::read_json_watchflower(QJsonObject &json)
         }
         if (infos.contains("colors_flower") && infos["colors_flower"].isArray())
         {
-            const QVariantList color = infos["flower_bract"].toArray().toVariantList();
+            const QVariantList color = infos["colors_flower"].toArray().toVariantList();
             for (const auto &c: color)
             {
                 colors_flower.push_back(c.toString());


### PR DESCRIPTION
The 'colors_flower' branch in Plant::read_json_watchflower checked
'colors_flower' but then read the array from 'flower_bract', a key
that doesn't exist (copy-paste from the adjacent colors_bract block).
toArray() on a missing value returns an empty array, so flower colors
were silently dropped on every plant cache round-trip via
DevicePlantSensor::setPlantName / loadPlant.
